### PR TITLE
Set USB serial number to truncated device ID

### DIFF
--- a/crates/chat-app/src/main.rs
+++ b/crates/chat-app/src/main.rs
@@ -255,6 +255,7 @@ async fn main(spawner: Spawner) {
         peripherals.USB0,
         peripherals.GPIO20,
         peripherals.GPIO19,
+        device_id,
     ));
 
     spawner.must_spawn(button_task(board_def.button, parameters));


### PR DESCRIPTION
This makes it easier to distinguish multiple connected devices when connecting