### PR TITLE
Fix application deployment to ESP32 board

### DIFF
--- a/crates/chat-app/TUTORIAL.md
+++ b/crates/chat-app/TUTORIAL.md
@@ -138,10 +138,10 @@ espflash write-bin 0x9000 params.bin
 Now it's time to deploy. Plug in your board to your computer using a usb-c cable while holding down the large black button on the board. (You can release the button after the usb cable is plugged into the dev board and computer.)
 
 ```
-cargo run
+cargo run --release
 ```
 
-This should ask you which device you want to connect to. If you don't see a serial device check that it is plugged in. If you can select the device but it will not upload the program you may need to unplug the board and plug it back in while holding down the large button on the board. Once it is plugged in you can release the button and retry the `cargo run` command.
+This should ask you which device you want to connect to. If you don't see a serial device check that it is plugged in. If you can select the device but it will not upload the program you may need to unplug the board and plug it back in while holding down the large button on the board. Once it is plugged in you can release the button and retry the `cargo run --release` command.
 
 This should write the program to the device. You will have to reset the
 device to get it working. The easiest way to do this is to unplug it and
@@ -193,4 +193,4 @@ new value.
 
 For a more detailed specification of the policy language, see our
 [policy language
-specification](https://github.com/aranya-project/aranya-docs/blob/main/docs/policy-v1.md).
+specification](https://github.com/aranya-project/aranya-docs/blob/main/docs/policy-v2.md).


### PR DESCRIPTION
Updated deployment instructions to use `cargo run --release` instead of `cargo run` (debug binary will be too large for ESP32 board application partition) and changed the policy language specification link to version 2.