### PR TITLE
Update call sites for aranya-runtime RuntimeBuffers and Spill API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,8 +128,8 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aranya-crypto"
-version = "0.14.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.14.1"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "aranya-id",
  "buggy",
@@ -171,7 +171,7 @@ dependencies = [
 [[package]]
 name = "aranya-id"
 version = "0.2.2"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "derive-where",
  "paste",
@@ -185,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ast"
-version = "0.13.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.15.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "aranya-policy-text",
  "rkyv",
@@ -197,8 +197,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-compiler"
-version = "0.22.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.24.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "annotate-snippets",
  "aranya-policy-ast",
@@ -214,8 +214,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-derive"
-version = "0.15.1"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.17.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "aranya-policy-lang",
  "prettyplease",
@@ -226,8 +226,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen"
-version = "0.22.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.24.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "aranya-policy-ifgen-macro",
  "aranya-policy-vm",
@@ -237,8 +237,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen-build"
-version = "0.15.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.17.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -253,8 +253,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen-macro"
-version = "0.7.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.8.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -263,8 +263,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-lang"
-version = "0.14.1"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.16.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -281,8 +281,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-module"
-version = "0.20.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.22.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "aranya-policy-ast",
  "fnv",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-text"
 version = "0.1.4"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "aranya-policy-text-macro",
  "proptest",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "aranya-policy-text-macro"
 version = "0.1.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "macro-string",
  "proc-macro2",
@@ -317,8 +317,8 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-vm"
-version = "0.21.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.23.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "aranya-crypto",
  "aranya-id",
@@ -334,20 +334,23 @@ dependencies = [
 
 [[package]]
 name = "aranya-runtime"
-version = "0.22.0"
-source = "git+https://github.com/aranya-project/aranya-core?branch=main#728641e352ef87b61e47318803a5eace38a65210"
+version = "0.24.0"
+source = "git+https://github.com/aranya-project/aranya-core?branch=main#25247720e262671ec726628f3c6e258eedefe680"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
  "buggy",
  "heapless",
  "postcard",
+ "rend",
+ "rkyv",
  "serde",
  "spideroak-base58",
  "thiserror",
  "tracing",
  "vec1",
  "yoke",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2551,6 +2554,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 dependencies = [
  "bytecheck",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/crates/chat-app/src/aranya/syncer.rs
+++ b/crates/chat-app/src/aranya/syncer.rs
@@ -1,11 +1,11 @@
-use alloc::{boxed::Box, collections::btree_map::BTreeMap, string::String, vec};
+use alloc::{boxed::Box, collections::btree_map::BTreeMap, string::String, vec, vec::Vec};
 use core::task::Poll;
 
 use aranya_crypto::Rng;
 use aranya_runtime::{
-    Address, Command, GraphId, PeerCache, PollIncoming, Segment, Storage, StorageProvider,
-    SyncError, SyncIncoming, SyncRequester, SyncResponder, Transaction, TraversalBuffer,
-    TraversalBuffers, MAX_SYNC_MESSAGE_SIZE,
+    Address, Command, GraphId, PeerCache, PollIncoming, RuntimeBuffers, Segment, Spill, Storage,
+    StorageError, StorageProvider, SyncError, SyncIncoming, SyncRequester, SyncResponder,
+    Transaction, MAX_SYNC_MESSAGE_SIZE,
 };
 use embassy_futures::{poll_once, yield_now};
 use embassy_time::{Duration, Instant};
@@ -100,7 +100,7 @@ where
     sink: PubSubSink<'a>,
     hello_boost: u8,
     last_hello: Instant,
-    buffers: TraversalBuffers,
+    buffers: RuntimeBuffers<<SP as StorageProvider>::Segment>,
 }
 
 impl<N> SyncEngine<'_, N>
@@ -118,7 +118,7 @@ where
             sink: PubSubSink::new(),
             hello_boost: 0,
             last_hello: Instant::from_ticks(0),
-            buffers: TraversalBuffers::new(),
+            buffers: RuntimeBuffers::new(),
         }
     }
 }
@@ -150,7 +150,7 @@ where
                         log::info!("sync_peer: sync stalled for {peer_addr}");
                         // sync is stalled. Commit any progress so far and close the session
                         if let Some(trx) = session.trx.take() {
-                            client.commit(trx, &mut self.sink, &mut self.buffers.primary)?;
+                            client.commit(trx, &mut self.sink, &mut self.buffers, VecSpill::new)?;
                         }
                         self.sync_session = None;
                         self.sync_queue.remove(&peer_addr);
@@ -165,7 +165,7 @@ where
                 &mut send_buf,
                 client.provider(),
                 peer_cache,
-                &mut self.buffers.primary,
+                &mut self.buffers.traversal.primary,
             )?
         };
         log::info!("sync_peer: sending Request len {len} to {peer_addr}");
@@ -261,7 +261,7 @@ where
                     &mut msg_buf,
                     client.provider(),
                     peer_cache,
-                    &mut self.buffers,
+                    &mut self.buffers.traversal,
                 )?
             };
             log::info!(
@@ -314,7 +314,7 @@ where
                     &mut self.sink,
                     client,
                     self.graph_id,
-                    &mut self.buffers.primary,
+                    &mut self.buffers,
                 )
                 .await?;
             }
@@ -325,7 +325,7 @@ where
             let req_session = self.sync_session.take().unwrap();
             if let Some(trx) = req_session.trx {
                 log::info!("process_response: commiting");
-                client.commit(trx, &mut self.sink, &mut self.buffers.primary)?;
+                client.commit(trx, &mut self.sink, &mut self.buffers, VecSpill::new)?;
                 log::info!("process_response: done commiting");
             } else {
                 log::error!("process_response: No transaction!!")
@@ -375,7 +375,7 @@ where
                     let provider = client.provider();
                     let storage = provider.get_storage(self.graph_id)?;
                     storage
-                        .get_location(hello.head, &mut self.buffers.primary)?
+                        .get_location(hello.head, &mut self.buffers.traversal.primary)?
                         .is_some()
                 };
 
@@ -399,20 +399,63 @@ async fn add_commands(
     sink: &mut PubSubSink<'_>,
     client: &mut Client,
     graph_id: GraphId,
-    buffer: &mut TraversalBuffer,
+    buffers: &mut RuntimeBuffers<<SP as StorageProvider>::Segment>,
 ) -> Result<()> {
     let trx = trx.get_or_insert_with(|| client.transaction(graph_id));
     dump_commands(cmds);
     for cmd in cmds.chunks(1) {
-        client.add_commands(trx, sink, cmd, buffer)?;
+        client.add_commands(trx, sink, cmd, buffers, VecSpill::new)?;
         yield_now().await;
     }
 
     // Update peer cache
     let addresses = cmds.iter().filter_map(|cmd| cmd.address().ok());
-    client.update_heads(graph_id, addresses, peer_cache, buffer)?;
+    client.update_heads(
+        graph_id,
+        addresses,
+        peer_cache,
+        &mut buffers.traversal.primary,
+    )?;
 
     Ok(())
+}
+
+/// In-memory spill for braid and convergence overflow data. The device has
+/// no filesystem, so file-backed spill is not an option.
+struct VecSpill {
+    buf: Vec<u8>,
+}
+
+impl VecSpill {
+    fn new() -> core::result::Result<Self, StorageError> {
+        Ok(Self { buf: Vec::new() })
+    }
+}
+
+impl Spill for VecSpill {
+    fn write_at(&mut self, offset: usize, data: &[u8]) -> core::result::Result<(), StorageError> {
+        let end = offset
+            .checked_add(data.len())
+            .ok_or(StorageError::IoError)?;
+        if end > self.buf.len() {
+            self.buf.resize(end, 0);
+        }
+        self.buf[offset..end].copy_from_slice(data);
+        Ok(())
+    }
+
+    fn read_at(
+        &mut self,
+        offset: usize,
+        data: &mut [u8],
+    ) -> core::result::Result<(), StorageError> {
+        let end = offset
+            .checked_add(data.len())
+            .ok_or(StorageError::IoError)?;
+        let src = self.buf.get(offset..end).ok_or(StorageError::IoError)?;
+        data.copy_from_slice(src);
+        Ok(())
+    }
 }
 
 fn dump_commands(cmds: &[impl Command]) {

--- a/crates/demo-esp32-s3/src/aranya/daemon.rs
+++ b/crates/demo-esp32-s3/src/aranya/daemon.rs
@@ -1,4 +1,4 @@
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use core::ops::DerefMut;
 
 use aranya_crypto::{
@@ -11,8 +11,8 @@ use aranya_crypto::{
     CipherSuite,
 };
 use aranya_runtime::{
-    linear::LinearStorageProvider, vm_action, ClientState, Command, GraphId, PeerCache, Sink,
-    Transaction, TraversalBuffer, VmEffect,
+    linear::LinearStorageProvider, vm_action, ClientState, Command, GraphId, PeerCache,
+    RuntimeBuffers, Sink, Spill, StorageError, StorageProvider, Transaction, VmEffect,
 };
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::MutexGuard};
 
@@ -35,6 +35,8 @@ pub(crate) type SP = LinearStorageProvider<GraphManager>;
 pub(crate) type SP = LinearStorageProvider<EspPartitionIoManager<FlashStorage>>;
 /// Aranya Client
 pub(crate) type Client = ClientState<PS, SP>;
+/// Caller-owned scratch buffers for graph-mutating operations
+pub(crate) type Buffers = RuntimeBuffers<<SP as StorageProvider>::Segment>;
 
 type KeyWrapKeyBytes = SecretKeyBytes<<<CS as CipherSuite>::Aead as Aead>::KeySize>;
 type KeyWrapKey = <<CS as CipherSuite>::Aead as Aead>::Key;
@@ -110,29 +112,30 @@ impl<S: Sink<VmEffect>> Imp<S> {
         cmds: &[impl Command + core::fmt::Debug],
         trx: &mut Option<Transaction<SP, PS>>,
         peer_cache: &mut PeerCache,
-        buffer: &mut TraversalBuffer,
+        buffers: &mut Buffers,
     ) -> Result<()> {
         let mut client = self.get_client().await;
         let trx = trx.get_or_insert_with(|| client.transaction(self.graph_id()));
         let mut sink = self.sink.lock().await;
         dump_commands(cmds);
-        client.add_commands(trx, sink.deref_mut(), cmds, buffer)?;
+        client.add_commands(trx, sink.deref_mut(), cmds, buffers, VecSpill::new)?;
 
         // Update peer cache
         let addresses = cmds.iter().filter_map(|cmd| cmd.address().ok());
-        client.update_heads(self.graph_id, addresses, peer_cache, buffer)?;
+        client.update_heads(
+            self.graph_id,
+            addresses,
+            peer_cache,
+            &mut buffers.traversal.primary,
+        )?;
 
         Ok(())
     }
 
-    pub async fn commit(
-        &self,
-        trx: Transaction<SP, PS>,
-        buffer: &mut TraversalBuffer,
-    ) -> Result<()> {
+    pub async fn commit(&self, trx: Transaction<SP, PS>, buffers: &mut Buffers) -> Result<()> {
         let mut client = self.get_client().await;
         let mut sink = self.sink.lock().await;
-        client.commit(trx, sink.deref_mut(), buffer)?;
+        client.commit(trx, sink.deref_mut(), buffers, VecSpill::new)?;
         Ok(())
     }
 
@@ -140,6 +143,44 @@ impl<S: Sink<VmEffect>> Imp<S> {
         let mut aranya = self.get_client().await;
         let mut sink = self.sink.lock().await;
         Ok(aranya.action(self.graph_id, sink.deref_mut(), action)?)
+    }
+}
+
+/// In-memory spill for braid and convergence overflow data. The device has
+/// no filesystem, so file-backed spill is not an option.
+pub(crate) struct VecSpill {
+    buf: Vec<u8>,
+}
+
+impl VecSpill {
+    pub(crate) fn new() -> core::result::Result<Self, StorageError> {
+        Ok(Self { buf: Vec::new() })
+    }
+}
+
+impl Spill for VecSpill {
+    fn write_at(&mut self, offset: usize, data: &[u8]) -> core::result::Result<(), StorageError> {
+        let end = offset
+            .checked_add(data.len())
+            .ok_or(StorageError::IoError)?;
+        if end > self.buf.len() {
+            self.buf.resize(end, 0);
+        }
+        self.buf[offset..end].copy_from_slice(data);
+        Ok(())
+    }
+
+    fn read_at(
+        &mut self,
+        offset: usize,
+        data: &mut [u8],
+    ) -> core::result::Result<(), StorageError> {
+        let end = offset
+            .checked_add(data.len())
+            .ok_or(StorageError::IoError)?;
+        let src = self.buf.get(offset..end).ok_or(StorageError::IoError)?;
+        data.copy_from_slice(src);
+        Ok(())
     }
 }
 

--- a/crates/demo-esp32-s3/src/aranya/syncer.rs
+++ b/crates/demo-esp32-s3/src/aranya/syncer.rs
@@ -9,14 +9,14 @@ use aranya_crypto::Rng;
 use aranya_runtime::{
     linear::LinearSegment, Address, Command, GraphId, Location, PeerCache, PollIncoming, Segment,
     Storage, StorageProvider, SyncError, SyncIncoming, SyncRequester, SyncResponder, Transaction,
-    TraversalBuffer, TraversalBuffers, MAX_SYNC_MESSAGE_SIZE,
+    MAX_SYNC_MESSAGE_SIZE,
 };
 use embassy_time::{Duration, Instant, Timer};
 use parameter_store::MAX_PEERS;
 
 use crate::{
     aranya::{
-        daemon::{PS, SP},
+        daemon::{Buffers, PS, SP},
         error::Result,
     },
     hardware::neopixel::NeopixelSink,
@@ -132,7 +132,7 @@ where
     /// Syncs with the peer.
     /// Aranya client sends a `SyncRequest` to peer. The `SyncResponse` is handled below in
     /// [`handle_message()`](Self::handle_message).
-    async fn sync_peer(&self, peer_addr: N::Addr, buffer: &mut TraversalBuffer) -> Result<()> {
+    async fn sync_peer(&self, peer_addr: N::Addr, buffers: &mut Buffers) -> Result<()> {
         let server_addr = self.network.my_address();
         let mut send_buf = vec![0u8; MAX_SYNC_MESSAGE_SIZE];
 
@@ -155,7 +155,7 @@ where
                         // sync is stalled. Commit any progress so far and remove this entry
                         let ses = entry.remove();
                         if let Some(trx) = ses.trx {
-                            self.imp.commit(trx, buffer).await?;
+                            self.imp.commit(trx, buffers).await?;
                         }
                     }
                     // Otherwise, we wait for this sync to proceed
@@ -166,7 +166,12 @@ where
             let mut peer_caches = self.peer_caches.lock().await;
             let peer_cache = peer_caches.entry(peer_addr).or_default();
             log::info!("peer_cache for {peer_addr}: {peer_cache:?}");
-            requester.poll(&mut send_buf, client.provider(), peer_cache, buffer)?
+            requester.poll(
+                &mut send_buf,
+                client.provider(),
+                peer_cache,
+                &mut buffers.traversal.primary,
+            )?
         };
         log::info!("sync_peer: sending Request len {len} to {peer_addr}");
         send_buf.truncate(len);
@@ -223,7 +228,7 @@ where
         &self,
         from: N::Addr,
         poll: PollIncoming,
-        buffers: &mut TraversalBuffers,
+        buffers: &mut Buffers,
     ) -> Result<()> {
         let mut responder = SyncResponder::new();
         responder.receive(poll)?;
@@ -236,7 +241,12 @@ where
             let len = {
                 let mut peer_caches = self.peer_caches.lock().await;
                 let peer_cache = peer_caches.entry(from).or_default();
-                responder.poll(&mut msg_buf, aranya.provider(), peer_cache, buffers)?
+                responder.poll(
+                    &mut msg_buf,
+                    aranya.provider(),
+                    peer_cache,
+                    &mut buffers.traversal,
+                )?
             };
             log::info!(
                 "sync_respond: responding to {from} with len {} loop {}",
@@ -258,7 +268,7 @@ where
         &self,
         from: N::Addr,
         bytes: &[u8],
-        buffer: &mut TraversalBuffer,
+        buffers: &mut Buffers,
     ) -> Result<()> {
         let mut sessions = self.sessions.lock().await;
         let req_session = &mut sessions.get_mut(&from).ok_or(SyncError::SessionMismatch)?;
@@ -271,7 +281,7 @@ where
                 let mut peer_caches = self.peer_caches.lock().await;
                 let peer_cache = peer_caches.entry(from).or_default();
                 self.imp
-                    .add_commands(&cmds, &mut req_session.trx, peer_cache, buffer)
+                    .add_commands(&cmds, &mut req_session.trx, peer_cache, buffers)
                     .await?;
             }
         } else {
@@ -281,7 +291,7 @@ where
             let req_session = sessions.remove(&from).unwrap();
             if let Some(trx) = req_session.trx {
                 log::info!("process_response: commiting");
-                self.imp.commit(trx, buffer).await?;
+                self.imp.commit(trx, buffers).await?;
                 log::info!("process_response: done commiting");
             } else {
                 log::info!("process_response: No transaction!!")
@@ -291,7 +301,7 @@ where
         Ok(())
     }
 
-    async fn handle_message(&self, buffers: &mut TraversalBuffers) -> Result<()> {
+    async fn handle_message(&self, buffers: &mut Buffers) -> Result<()> {
         let msg = self.network.recv_message().await?;
         let (from, sm) = SyncMessage::from_message(msg)?;
         log::info!(
@@ -308,7 +318,7 @@ where
                 };
             }
             SyncMessageType::Response => {
-                self.process_response(from, &sm.bytes, &mut buffers.primary).await?;
+                self.process_response(from, &sm.bytes, buffers).await?;
             }
             SyncMessageType::Hello => {
                 let hello: HelloMessage<N> = postcard::from_bytes(&sm.bytes)?;
@@ -321,12 +331,14 @@ where
                     let mut aranya = self.imp.get_client().await;
                     let provider = aranya.provider();
                     let storage = provider.get_storage(graph_id)?;
-                    storage.get_location(head, &mut buffers.primary)?.is_some()
+                    storage
+                        .get_location(head, &mut buffers.traversal.primary)?
+                        .is_some()
                 };
 
                 if !has_address {
                     let address = hello.address;
-                    self.sync_peer(address, &mut buffers.primary).await?;
+                    self.sync_peer(address, buffers).await?;
                 }
             }
         }
@@ -335,7 +347,7 @@ where
 
     /// Wait forever for requests and handle them. This does not return.
     async fn serve(&self) -> ! {
-        let mut buffers = TraversalBuffers::new();
+        let mut buffers = Buffers::new();
         loop {
             match self.handle_message(&mut buffers).await {
                 Ok(_) => (),


### PR DESCRIPTION
aranya-core main now requires callers of `ClientState::add_commands` / `ClientState::commit` to pass caller-owned `RuntimeBuffers` plus a spill factory for braid and convergence overflow (from aranya-core's fsync optimization work). This has been breaking the `build-embedded` CI job in aranya-core since June 30.

- Thread `RuntimeBuffers` through the chat-app and demo-esp32-s3 syncers (replacing the bare `TraversalBuffer`/`TraversalBuffers` plumbing; sync calls use the embedded `buffers.traversal`).
- Add a `Vec`-backed `Spill` impl in each app, since the devices have no filesystem for the file-backed `LibcSpill`.
- Update `Cargo.lock` to the current aranya-core main (`25247720`).

Verified locally with the esp toolchain: `cargo check` passes for chat-app and demo-esp32-s3 with default features and with `--no-default-features --features storage-internal,spideroak-demo-v2 --features net-irda`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)